### PR TITLE
v6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,165 @@
 # Default light syntax theme for Inkdrop Markdown Editor
+
+The built-in default **light** syntax theme for [Inkdrop](https://www.inkdrop.app/).
+It also doubles as a **reference implementation** for anyone who wants to build their
+own syntax theme for Inkdrop (which runs on [CodeMirror 6](https://codemirror.net/)),
+or migrate a theme written for older versions.
+
+If you just want to read the code, the whole theme is a single stylesheet:
+[`styles/index.css`](./styles/index.css).
+
+---
+
+## How a syntax theme is packaged
+
+A syntax theme is an ordinary Inkdrop package whose `package.json` declares a `theme`
+of type `"syntax"` and points at one or more stylesheets:
+
+```json
+{
+  "name": "my-syntax",
+  "version": "1.0.0",
+  "description": "My syntax theme",
+  "theme": "syntax",
+  "styleSheets": ["index.css"],
+  "engines": { "inkdrop": "^6.x" }
+}
+```
+
+- `theme: "syntax"` — tells Inkdrop this package paints the editor/preview, as opposed
+  to a UI theme.
+- `styleSheets` — paths (relative to `styles/`) loaded into the app, in order.
+- `engines.inkdrop: "^6.x"` — target Inkdrop 6. (Older themes targeted `^5.x`; see
+  [Migrating](#migrating-an-older-theme) below.)
+
+Two slots exist in Inkdrop: a **UI theme** and a **syntax theme**, chosen independently
+in _Preferences → Themes_. This package fills the syntax slot.
+
+---
+
+## Quick start
+
+Read the [theme development guide](https://developers.inkdrop.app/guides/create-a-theme).
+
+## Anatomy of `styles/index.css`
+
+The stylesheet is organised as a stack of layers, each referring only to the one above
+it. Re-skinning the theme is mostly a matter of editing the top layers and leaving the
+bottom ones alone.
+
+```
+primitive tokens  (@inkdropapp/css)   →   --hsl-slate-800, --hsl-blue-500, …
+        │
+16-slot palette   (--hsl-baseNN)      →   one primitive per slot
+        │
+resolved colours  (--bd-baseNN)       →   hsl(var(--hsl-baseNN))
+        │
+semantic vars     (--editor-*, --md-*)→   editor chrome & markdown decorations
+        │
+syntax classes    (.tok-*, .md-*)     →   the actual highlighting rules
+```
+
+### Primitive color tokens
+
+The lowest layer is **not** defined here. The primitive palette — a Tailwind-style ramp
+of `--hsl-<family>-<scale>` triplets (`--hsl-slate-50` … `--hsl-slate-950`, plus
+`--hsl-white` / `--hsl-black`) — lives in the shared **`@inkdropapp/css`** package and is
+loaded by the app before your theme:
+
+> **Primitive color tokens are defined in
+> <https://github.com/inkdropapp/css/blob/main/tokens.css>**
+
+Families available: `slate`, `gray`, `zinc`, `neutral`, `stone`, `red`, `orange`,
+`amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`,
+`violet`, `purple`, `fuchsia`, `pink`, `rose` — each in scales `50, 100, … 900, 950`.
+
+The values are **HSL triplets** (e.g. `220deg 16% 22%`), not finished colours, so you
+wrap them in `hsl()` and can add an alpha channel:
+
+```css
+color: hsl(var(--hsl-blue-500)); /* opaque   */
+background: hsl(var(--hsl-blue-400) / 40%); /* 40% alpha */
+```
+
+### Semantic variables
+
+The palette then feeds two families of semantic variables, also in `:root`:
+
+- **`--editor-*`** — editor chrome: foreground/background, caret, selection, gutter,
+  active line, tooltips & autocomplete, matching brackets, search matches, whitespace
+  rendering, fold placeholders, etc. For example:
+
+  ```css
+  --editor-foreground-color: var(--bd-base01);
+  --editor-background-color: var(--bd-base00);
+  --editor-caret-color: var(--bd-cursor);
+  --editor-selection-background: hsl(var(--hsl-slate-500) / 40%);
+  ```
+
+- **`--md-*`** — Markdown decorations: code blocks, tables, blockquotes, inline marks:
+
+  ```css
+  --md-codeblock-background-color: hsl(var(--hsl-slate-50));
+  --md-table-border-color: hsl(var(--hsl-slate-200));
+  --md-blockquote-border-color: var(--bd-base06);
+  ```
+
+These variable names are the theming contract Inkdrop consumes — keep the names, change
+the values.
+
+### Syntax classes
+
+Finally, the actual highlighting. Inkdrop's highlighter emits `.tok-*` classes (one per
+[Lezer](https://lezer.codemirror.net/) highlight tag) inside `.cm-editor` and inside
+rendered preview code blocks (`.mde-preview .codeblock`):
+
+```css
+.cm-editor,
+.mde-preview .codeblock {
+  .tok-keyword {
+    color: var(--bd-base0D);
+  }
+  .tok-string {
+    color: var(--bd-base0C);
+  }
+  .tok-comment {
+    color: var(--bd-base06);
+    font-style: italic;
+  }
+  /* …one rule per token kind… */
+}
+```
+
+Alongside the `.tok-*` rules are **`.md-*` mark classes** for the Markdown source markers
+themselves — `.md-header-mark`, `.md-list-mark`, `.md-emphasis-mark`, `.md-code-mark`,
+`.md-task-marker`, etc. — which let you dim or restyle the literal `#`, `-`, `*` and
+`` ` `` characters. Leave a rule empty (`{}`) to inherit the default; the file keeps a
+few empty placeholders as documentation of what's stylable.
+
+> This file uses **native CSS nesting** (no preprocessor). Inkdrop 6 ships modern CSS, so
+> nesting, `@layer`, and `hsl(... / alpha)` all work without a build step.
+
+---
+
+## Migrating an older theme
+
+Porting a theme from Inkdrop 5 (CodeMirror 5, usually authored in LESS) to Inkdrop 6 /
+CodeMirror 6? See **[Plugin Migration Guide from v5 to v6 → Syntax themes](https://developer.inkdrop.app/appendix/plugin-migration-from-v5-to-v6#syntax-themes)**.
+
+It covers the `.CodeMirror-*` → `--editor-*` variable mapping and the `.cm-*` → `.tok-*`
+token-class mapping. The [anatomy](#anatomy-of-stylesindexcss) above is what you're
+migrating _to_.
+
+---
+
+## Reference
+
+- Primitive color tokens — <https://github.com/inkdropapp/css/blob/main/tokens.css>
+- This theme's source — [`styles/index.css`](./styles/index.css)
+- CodeMirror 6 themes (the underlying npm packages) —
+  [inkdropapp/cm6-themes](https://github.com/inkdropapp/cm6-themes)
+- Inkdrop documentation — <https://docs.inkdrop.app/>
+
+## License
+
+[MIT](./LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "default-light-syntax",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "default-light-syntax",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "engines": {
-        "inkdrop": "^5.x"
+        "inkdrop": "^6.x"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "index.css"
   ],
   "engines": {
-    "inkdrop": "^5.x"
+    "inkdrop": "^6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "name": "default-light-syntax",
   "description": "Default light syntax theme",
   "theme": "syntax",
-  "scripts": {
-    "build": "lessc styles/less/default.less ./styles/index.css"
-  },
+  "scripts": {},
   "styleSheets": [
     "index.css"
   ],

--- a/styles/index.css
+++ b/styles/index.css
@@ -48,6 +48,7 @@
   --editor-gutter-border-right: 1px solid hsl(var(--hsl-slate-200));
   --editor-gutter-color: var(--bd-base06);
   --editor-gutter-background-color: transparent;
+  --editor-gutter-background-solid-color: hsl(var(--hsl-white));
   --editor-active-line-gutter-background-color: var(--bd-bg-highlight);
   --editor-panel-background-color: hsl(var(--hsl-slate-50));
   --editor-panel-color: var(--bd-base03);

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,7 @@
 :root {
+  /**
+   * Primitive design tokens are defined in https://github.com/inkdropapp/css/blob/main/tokens.css
+   */
   --hsl-base00: var(--hsl-white);
   --hsl-base01: var(--hsl-slate-800);
   --hsl-base02: var(--hsl-blue-600);
@@ -38,6 +41,9 @@
   --bd-selection: hsl(var(--hsl-blue-400) / 40%);
   --bd-cursor: hsl(var(--hsl-base0D));
 
+  /**
+   * Editor UI colors
+   */
   --editor-foreground-color: var(--bd-base01);
   --editor-background-color: var(--bd-base00);
   --editor-caret-color: var(--bd-cursor);
@@ -94,7 +100,7 @@
   --editor-nes-ghost-color: var(--bd-base06);
   --editor-highlight-space-color: hsl(var(--hsl-slate-100));
   --editor-highlight-tab-background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>');
-  --editor-highlight-tab-filter: 'none';
+  --editor-highlight-tab-filter: "none";
   --editor-highlight-tab-opacity: 0.3;
   --editor-trailing-space-background-color: hsl(var(--hsl-red-200));
   --editor-fold-placeholder-border-radius: 0.2em;
@@ -104,10 +110,19 @@
   --editor-image-widget-backdrop-background-color: hsl(var(--hsl-slate-100));
   --editor-image-widget-backdrop-border: 1px solid hsl(var(--hsl-slate-200));
 
+  /**
+   * Markdown-specific colors
+   */
+  --md-inline-code-padding: 1px;
+  --md-inline-code-border-color: hsl(var(--hsl-slate-200));
+  --md-inline-code-border-width: 1px;
+  --md-inline-code-background-color: hsl(var(--hsl-slate-50));
+  --md-codeblock-color: var(--editor-foreground-color);
   --md-codeblock-border-color: hsl(var(--hsl-slate-200));
   --md-codeblock-border-width: 1px;
   --md-codeblock-background-color: hsl(var(--hsl-slate-50));
 
+  --md-inline-mark-text-color: var(--editor-foreground-color);
   --md-inline-mark-background-color: hsl(var(--hsl-yellow-500) / 30%);
   --md-inline-mark-underline-color: hsl(var(--hsl-yellow-500));
 
@@ -119,7 +134,7 @@
 }
 
 /*============================================================================
-  Syntax colours (classes produced by tokenHighlighter.ts)
+  Syntax colors (classes produced by tokenHighlighter.ts)
   ===========================================================================*/
 .cm-editor,
 .mde-preview .codeblock {
@@ -154,7 +169,7 @@
     color: var(--bd-base09);
   }
 
-  /* colour literals, constants, std-lib names --------------------------*/
+  /* color literals, constants, std-lib names --------------------------*/
   .tok-color,
   .tok-name.tok-constant,
   .tok-name.tok-standard {

--- a/styles/index.css
+++ b/styles/index.css
@@ -45,6 +45,7 @@
   --editor-focused-selection-background: var(--bd-selection);
   --editor-active-line-background-color: var(--bd-bg-highlight);
   --editor-special-char-color: var(--bd-base0B);
+  --editor-spelling-error-color: var(--negative-color);
   --editor-gutter-border-right: 1px solid hsl(var(--hsl-slate-200));
   --editor-gutter-color: var(--bd-base06);
   --editor-gutter-background-color: transparent;

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,23 +1,20 @@
 :root {
-  /* Light theme colors based on Nord-inspired palette */
-  --hsl-base00: 218 27% 94%; /* Light background (was Polar Night base00) */
-  --hsl-base01: 220 17% 32%; /* Dark text (was base02) */
-  --hsl-base02: 210 44% 63%; /* Light blue for highlights (was base09) */
-  --hsl-base03: 220 16% 36%; /* Medium dark gray for comments */
-  --hsl-base04: 220 17% 45%; /* Darker gray */
-  --hsl-base05: 219 28% 88%; /* Light gray */
-  --hsl-base06: 220 16% 40%; /* Medium gray */
-  --hsl-base07: 220 16% 22%; /* Very dark (was base00) */
-
-  /* Aurora colors - keeping similar hues but adjusted for light theme */
-  --hsl-base08: 354 62% 56%; /* Red (was base0B) */
-  --hsl-base09: 14 61% 63%; /* Orange (was base0C) */
-  --hsl-base0A: 40 81% 65%; /* Yellow - slightly darker (was base0D) */
-  --hsl-base0B: 92 38% 55%; /* Green (was base0E) */
-  --hsl-base0C: 179 25% 65%; /* Cyan (was base07) */
-  --hsl-base0D: 210 44% 63%; /* Blue (was base09) */
-  --hsl-base0E: 311 40% 63%; /* Purple (was base0F) */
-  --hsl-base0F: 213 42% 52%; /* Dark blue (was base0A) */
+  --hsl-base00: var(--hsl-white);
+  --hsl-base01: var(--hsl-slate-800);
+  --hsl-base02: var(--hsl-blue-600);
+  --hsl-base03: var(--hsl-slate-600);
+  --hsl-base04: var(--hsl-slate-400);
+  --hsl-base05: var(--hsl-slate-300);
+  --hsl-base06: var(--hsl-slate-500);
+  --hsl-base07: var(--hsl-slate-900);
+  --hsl-base08: var(--hsl-red-600);
+  --hsl-base09: var(--hsl-orange-600);
+  --hsl-base0A: var(--hsl-amber-600);
+  --hsl-base0B: var(--hsl-teal-600);
+  --hsl-base0C: var(--hsl-green-600);
+  --hsl-base0D: var(--hsl-blue-500);
+  --hsl-base0E: var(--hsl-purple-600);
+  --hsl-base0F: var(--hsl-indigo-500);
 
   --bd-base00: hsl(var(--hsl-base00));
   --bd-base01: hsl(var(--hsl-base01));
@@ -37,35 +34,35 @@
   --bd-base0F: hsl(var(--hsl-base0F));
 
   --bd-bg: var(--bd-base00);
-  --bd-bg-highlight: hsl(var(--hsl-base02) / 10%);
-  --bd-selection: hsl(var(--hsl-base02) / 20%);
-  --bd-cursor: hsl(var(--hsl-base0F));
+  --bd-bg-highlight: hsl(var(--hsl-blue-300) / 10%);
+  --bd-selection: hsl(var(--hsl-blue-400) / 40%);
+  --bd-cursor: hsl(var(--hsl-base0D));
 
   --editor-foreground-color: var(--bd-base01);
   --editor-background-color: var(--bd-base00);
   --editor-caret-color: var(--bd-cursor);
-  --editor-selection-background: var(--bd-selection);
+  --editor-selection-background: hsl(var(--hsl-slate-500) / 40%);
   --editor-focused-selection-background: var(--bd-selection);
   --editor-active-line-background-color: var(--bd-bg-highlight);
   --editor-special-char-color: var(--bd-base0B);
-  --editor-gutter-border-right: none;
+  --editor-gutter-border-right: 1px solid hsl(var(--hsl-slate-200));
   --editor-gutter-color: var(--bd-base06);
   --editor-gutter-background-color: transparent;
   --editor-active-line-gutter-background-color: var(--bd-bg-highlight);
-  --editor-panel-background-color: hsl(var(--hsl-base05));
+  --editor-panel-background-color: hsl(var(--hsl-slate-50));
   --editor-panel-color: var(--bd-base03);
   --editor-panel-border-color: var(--border-color);
   --editor-tooltip-border-style: solid;
   --editor-tooltip-border-width: 1px;
-  --editor-tooltip-border-color: var(--bd-base04);
+  --editor-tooltip-border-color: hsl(var(--hsl-slate-200));
   --editor-tooltip-border-radius: 0.4em;
-  --editor-tooltip-background-color: hsl(var(--hsl-base00));
-  --editor-tooltip-box-shadow: 0px 1px 2px 0 rgba(0, 0, 0, 0.1);
+  --editor-tooltip-background-color: hsl(var(--hsl-white));
+  --editor-tooltip-box-shadow: 0px 2px 4px 0 hsl(var(--hsl-slate-200));
   --editor-tooltip-autocomplete-padding: 0.2em;
   --editor-tooltip-autocomplete-item-border-radius: 0.2em;
   --editor-tooltip-autocomplete-item-padding: 0 0.8em;
-  --editor-tooltip-autocomplete-item-selected-background-color: var(
-    --bd-bg-highlight
+  --editor-tooltip-autocomplete-item-selected-background-color: hsl(
+    var(--hsl-blue-100)
   );
   --editor-tooltip-autocomplete-section-border-color: var(--bd-base06);
   --editor-tooltip-autocomplete-item-selected-color: var(--bd-base01);
@@ -78,36 +75,36 @@
   --editor-completion-detail-text-decoration: none;
   --editor-completion-detail-font-style: normal;
   --editor-completion-detail-font-weight: normal;
-  --editor-matching-bracket-outline: 1px solid hsl(var(--hsl-base0D) / 90%);
-  --editor-matching-bracket-background-color: hsl(var(--hsl-base02) / 10%);
+  --editor-matching-bracket-outline: 1px solid hsl(var(--hsl-blue-500));
+  --editor-matching-bracket-background-color: hsl(var(--hsl-blue-100));
   --editor-nonmatching-bracket-outline: 1px solid var(--bd-base03);
   --editor-nonmatching-bracket-background-color: transparent;
-  --editor-selection-match-background-color: hsl(var(--hsl-base0C) / 30%);
+  --editor-selection-match-background-color: hsl(var(--hsl-yellow-200));
   --editor-selection-match-outline: none;
-  --editor-search-match-background-color: hsl(var(--hsl-base0A) / 40%);
+  --editor-search-match-background-color: hsl(var(--hsl-yellow-300));
   --editor-search-match-outline: none;
-  --editor-search-match-selected-background-color: hsl(var(--hsl-base09) / 40%);
-  --editor-search-match-selected-outline: 1px solid var(--bd-base02);
+  --editor-search-match-selected-background-color: hsl(var(--hsl-orange-300));
+  --editor-search-match-selected-outline: 1px solid var(--bd-base09);
   --editor-placeholder-color: var(--bd-base06);
-  --editor-highlight-space-color: var(--bd-bg-highlight);
+  --editor-highlight-space-color: hsl(var(--hsl-slate-100));
   --editor-highlight-tab-background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>');
   --editor-highlight-tab-filter: 'none';
   --editor-highlight-tab-opacity: 0.3;
-  --editor-trailing-space-background-color: var(--bd-base08);
+  --editor-trailing-space-background-color: hsl(var(--hsl-red-200));
   --editor-fold-placeholder-border-radius: 0.2em;
   --editor-fold-placeholder-color: var(--bd-base00);
-  --editor-fold-placeholder-border: 1px solid var(--bd-base03);
-  --editor-fold-placeholder-background-color: var(--bd-base05);
-  --editor-image-widget-backdrop-background-color: hsl(var(--hsl-base03) / 10%);
-  --editor-image-widget-backdrop-border: 1px solid var(--bd-base04);
+  --editor-fold-placeholder-border: 1px solid var(--bd-base04);
+  --editor-fold-placeholder-background-color: var(--bd-base04);
+  --editor-image-widget-backdrop-background-color: hsl(var(--hsl-slate-100));
+  --editor-image-widget-backdrop-border: 1px solid hsl(var(--hsl-slate-200));
 
-  --md-codeblock-border-color: var(--bd-base04);
+  --md-codeblock-border-color: hsl(var(--hsl-slate-200));
   --md-codeblock-border-width: 1px;
-  --md-codeblock-background-color: hsl(var(--hsl-base07) / 5%);
+  --md-codeblock-background-color: hsl(var(--hsl-slate-50));
 
-  --md-table-border-color: var(--bd-base04);
+  --md-table-border-color: hsl(var(--hsl-slate-200));
   --md-table-border-width: 1px;
-  --md-table-background-color: hsl(var(--hsl-base05));
+  --md-table-background-color: hsl(var(--hsl-slate-50));
 
   --md-blockquote-border-color: var(--bd-base06);
 }
@@ -121,7 +118,7 @@
   .tok-keyword,
   .tok-operator-keyword,
   .tok-module-keyword {
-    color: var(--bd-base0F);
+    color: var(--bd-base0D);
   }
 
   /* basic names, deletes, chars, prop- & macro-names -------------------*/
@@ -135,7 +132,7 @@
 
   /* variable names -----------------------------------------------------*/
   .tok-variable-name {
-    color: var(--bd-base0F);
+    color: var(--bd-base09);
   }
 
   /* function identifiers & calls --------------------------------------*/
@@ -167,7 +164,7 @@
   .tok-brace,
   .tok-square-bracket,
   .tok-angle-bracket {
-    color: var(--bd-base06);
+    color: var(--bd-base0E);
   }
 
   /* annotations (highlighted in warning orange) ------------------------*/
@@ -187,7 +184,7 @@
   /* type & class names -------------------------------------------------*/
   .tok-type-name,
   .tok-class-name {
-    color: var(--bd-base0F);
+    color: var(--bd-base0D);
   }
 
   /* operators ----------------------------------------------------------*/
@@ -200,37 +197,40 @@
   .tok-update-operator,
   .tok-definition-operator,
   .tok-control-operator {
-    color: var(--bd-base06);
+    color: var(--bd-base0E);
   }
 
   /* HTML/XML tag names -------------------------------------------------*/
   .tok-tag-name {
-    color: var(--bd-base0C);
+    color: var(--bd-base0B);
   }
 
   /* attribute names ----------------------------------------------------*/
   .tok-attribute-name {
-    color: var(--bd-base0F);
+    color: var(--bd-base0D);
   }
 
   /* regular expressions -----------------------------------------------*/
   .tok-regexp {
-    color: var(--bd-base0B);
+    color: var(--bd-base09);
   }
 
   /* quotes / block-quotes ---------------------------------------------*/
-  .tok-quote:not(.md-alert) {
-    color: var(--bd-base0E);
+  @layer quote {
+    .tok-quote:not(.md-alert) {
+      color: var(--bd-base06);
+      font-style: italic;
+    }
   }
 
   /* strings ------------------------------------------------------------*/
   .tok-string {
-    color: var(--bd-base0B);
+    color: var(--bd-base0C);
   }
 
   /* links --------------------------------------------------------------*/
   .tok-link {
-    color: var(--bd-base0D);
+    color: var(--bd-base0F);
     text-decoration: underline;
     text-underline-position: under;
   }
@@ -240,7 +240,7 @@
   .tok-link.tok-url,
   .tok-escape,
   .tok-string.tok-special {
-    color: var(--bd-base0D);
+    color: var(--bd-base0B);
   }
 
   /* meta / pre-processor ----------------------------------------------*/
@@ -260,16 +260,15 @@
   /* monospace (inline code) -------------------------------------------*/
   .tok-monospace {
     color: var(--bd-base01);
-    background: hsl(var(--hsl-base07) / 5%);
   }
 
   /* emphasis variants --------------------------------------------------*/
   .tok-strong {
-    color: var(--bd-base08);
+    color: var(--bd-base09);
     font-weight: bold;
   }
   .tok-emphasis {
-    color: var(--bd-base0E);
+    color: var(--bd-base09);
     font-style: italic;
   }
   .tok-strikethrough {
@@ -284,7 +283,7 @@
   .tok-heading-4,
   .tok-heading-5,
   .tok-heading-6 {
-    color: var(--bd-base07);
+    color: var(--bd-base0D);
     font-weight: bold;
   }
 
@@ -292,7 +291,7 @@
   .tok-atom,
   .tok-bool,
   .tok-variable-name.tok-special {
-    color: var(--bd-base09);
+    color: var(--bd-base0B);
   }
 
   /* processing instructions & inserted text ---------------------------*/
@@ -319,16 +318,16 @@
     /* add styles if desired */
   }
   .md-quote-mark.tok-quote {
-    color: var(--bd-base0E);
+    color: var(--bd-base06);
   }
   .md-list-mark {
-    /* … */
+    color: var(--bd-base0F);
   }
   .md-link-mark {
     /* … */
   }
   .md-emphasis-mark {
-    /* … */
+    opacity: 0.6;
   }
   .md-code-mark {
     /* … */

--- a/styles/index.css
+++ b/styles/index.css
@@ -102,6 +102,9 @@
   --md-codeblock-border-width: 1px;
   --md-codeblock-background-color: hsl(var(--hsl-slate-50));
 
+  --md-inline-mark-background-color: hsl(var(--hsl-yellow-500) / 30%);
+  --md-inline-mark-underline-color: hsl(var(--hsl-yellow-500));
+
   --md-table-border-color: hsl(var(--hsl-slate-200));
   --md-table-border-width: 1px;
   --md-table-background-color: hsl(var(--hsl-slate-50));

--- a/styles/index.css
+++ b/styles/index.css
@@ -67,6 +67,9 @@
   );
   --editor-tooltip-autocomplete-section-border-color: var(--bd-base06);
   --editor-tooltip-autocomplete-item-selected-color: var(--bd-base01);
+  --editor-inline-tooltip-color: hsl(var(--hsl-slate-600));
+  --editor-inline-tooltip-background-color: hsl(var(--hsl-white));
+  --editor-inline-tooltip-outline: 1px solid hsl(var(--hsl-blue-300) / 30%);
   --editor-completion-label: var(--bd-base03);
   --editor-completion-matched-text-color: var(--bd-base01);
   --editor-completion-matched-text-decoration: none;
@@ -87,6 +90,7 @@
   --editor-search-match-selected-background-color: hsl(var(--hsl-orange-300));
   --editor-search-match-selected-outline: 1px solid var(--bd-base09);
   --editor-placeholder-color: var(--bd-base06);
+  --editor-nes-ghost-color: var(--bd-base06);
   --editor-highlight-space-color: hsl(var(--hsl-slate-100));
   --editor-highlight-tab-background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>');
   --editor-highlight-tab-filter: 'none';

--- a/styles/index.css
+++ b/styles/index.css
@@ -55,7 +55,7 @@
   --editor-tooltip-border-style: solid;
   --editor-tooltip-border-width: 1px;
   --editor-tooltip-border-color: hsl(var(--hsl-slate-200));
-  --editor-tooltip-border-radius: 0.4em;
+  --editor-tooltip-border-radius: 0.8em;
   --editor-tooltip-background-color: hsl(var(--hsl-white));
   --editor-tooltip-box-shadow: 0px 2px 4px 0 hsl(var(--hsl-slate-200));
   --editor-tooltip-autocomplete-padding: 0.2em;

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,216 +1,344 @@
-.editor {
-  /* Polar Night */
-  --base00: hsl(220 16% 22%);
-  --base01: hsl(222 16% 28%);
-  --base02: hsl(220 17% 32%);
-  --base03: hsl(220 16% 40%);
+:root {
+  /* Light theme colors based on Nord-inspired palette */
+  --hsl-base00: 218 27% 94%; /* Light background (was Polar Night base00) */
+  --hsl-base01: 220 17% 32%; /* Dark text (was base02) */
+  --hsl-base02: 210 44% 63%; /* Light blue for highlights (was base09) */
+  --hsl-base03: 220 16% 36%; /* Medium dark gray for comments */
+  --hsl-base04: 220 17% 45%; /* Darker gray */
+  --hsl-base05: 219 28% 88%; /* Light gray */
+  --hsl-base06: 220 16% 40%; /* Medium gray */
+  --hsl-base07: 220 16% 22%; /* Very dark (was base00) */
 
-  /* Snow Storm */
-  --base04: hsl(219 28% 88%);
-  --base05: hsl(218 27% 92%);
-  --base06: hsl(218 27% 94%);
+  /* Aurora colors - keeping similar hues but adjusted for light theme */
+  --hsl-base08: 354 62% 56%; /* Red (was base0B) */
+  --hsl-base09: 14 61% 63%; /* Orange (was base0C) */
+  --hsl-base0A: 40 81% 65%; /* Yellow - slightly darker (was base0D) */
+  --hsl-base0B: 92 38% 55%; /* Green (was base0E) */
+  --hsl-base0C: 179 25% 65%; /* Cyan (was base07) */
+  --hsl-base0D: 210 44% 63%; /* Blue (was base09) */
+  --hsl-base0E: 311 40% 63%; /* Purple (was base0F) */
+  --hsl-base0F: 213 42% 52%; /* Dark blue (was base0A) */
 
-  /* Frost */
-  --base07: hsl(179 25% 65%);
-  --base08: hsl(193 43% 67%);
-  --base09: hsl(210 44% 63%);
-  --base0A: hsl(213 42% 52%);
+  --bd-base00: hsl(var(--hsl-base00));
+  --bd-base01: hsl(var(--hsl-base01));
+  --bd-base02: hsl(var(--hsl-base02));
+  --bd-base03: hsl(var(--hsl-base03));
+  --bd-base04: hsl(var(--hsl-base04));
+  --bd-base05: hsl(var(--hsl-base05));
+  --bd-base06: hsl(var(--hsl-base06));
+  --bd-base07: hsl(var(--hsl-base07));
+  --bd-base08: hsl(var(--hsl-base08));
+  --bd-base09: hsl(var(--hsl-base09));
+  --bd-base0A: hsl(var(--hsl-base0A));
+  --bd-base0B: hsl(var(--hsl-base0B));
+  --bd-base0C: hsl(var(--hsl-base0C));
+  --bd-base0D: hsl(var(--hsl-base0D));
+  --bd-base0E: hsl(var(--hsl-base0E));
+  --bd-base0F: hsl(var(--hsl-base0F));
 
-  /* Aurora */
-  --base0B: hsl(354 62% 56%);
-  --base0C: hsl(14 61% 63%);
-  --base0D: hsl(40 81% 73%);
-  --base0E: hsl(92 38% 55%);
-  --base0F: hsl(311 40% 63%);
+  --bd-bg: var(--bd-base00);
+  --bd-bg-highlight: hsl(var(--hsl-base02) / 10%);
+  --bd-selection: hsl(var(--hsl-base02) / 20%);
+  --bd-cursor: hsl(var(--hsl-base0F));
 
-  .CodeMirror {
-    /* Background color of main window */
-    background-color: transparent;
-    color: var(--base02);
-    --fat-cursor-color: var(--base08);
+  --editor-foreground-color: var(--bd-base01);
+  --editor-background-color: var(--bd-base00);
+  --editor-caret-color: var(--bd-cursor);
+  --editor-selection-background: var(--bd-selection);
+  --editor-focused-selection-background: var(--bd-selection);
+  --editor-active-line-background-color: var(--bd-bg-highlight);
+  --editor-special-char-color: var(--bd-base0B);
+  --editor-gutter-border-right: none;
+  --editor-gutter-color: var(--bd-base06);
+  --editor-gutter-background-color: transparent;
+  --editor-active-line-gutter-background-color: var(--bd-bg-highlight);
+  --editor-panel-background-color: hsl(var(--hsl-base05));
+  --editor-panel-color: var(--bd-base03);
+  --editor-panel-border-color: var(--border-color);
+  --editor-tooltip-border-style: solid;
+  --editor-tooltip-border-width: 1px;
+  --editor-tooltip-border-color: var(--bd-base04);
+  --editor-tooltip-border-radius: 0.4em;
+  --editor-tooltip-background-color: hsl(var(--hsl-base00));
+  --editor-tooltip-box-shadow: 0px 1px 2px 0 rgba(0, 0, 0, 0.1);
+  --editor-tooltip-autocomplete-padding: 0.2em;
+  --editor-tooltip-autocomplete-item-border-radius: 0.2em;
+  --editor-tooltip-autocomplete-item-padding: 0 0.8em;
+  --editor-tooltip-autocomplete-item-selected-background-color: var(
+    --bd-bg-highlight
+  );
+  --editor-tooltip-autocomplete-section-border-color: var(--bd-base06);
+  --editor-tooltip-autocomplete-item-selected-color: var(--bd-base01);
+  --editor-completion-label: var(--bd-base03);
+  --editor-completion-matched-text-color: var(--bd-base01);
+  --editor-completion-matched-text-decoration: none;
+  --editor-completion-matched-text-font-style: normal;
+  --editor-completion-matched-text-font-weight: bold;
+  --editor-completion-detail-color: var(--bd-base0C);
+  --editor-completion-detail-text-decoration: none;
+  --editor-completion-detail-font-style: normal;
+  --editor-completion-detail-font-weight: normal;
+  --editor-matching-bracket-outline: 1px solid hsl(var(--hsl-base0D) / 90%);
+  --editor-matching-bracket-background-color: hsl(var(--hsl-base02) / 10%);
+  --editor-nonmatching-bracket-outline: 1px solid var(--bd-base03);
+  --editor-nonmatching-bracket-background-color: transparent;
+  --editor-selection-match-background-color: hsl(var(--hsl-base0C) / 30%);
+  --editor-selection-match-outline: none;
+  --editor-search-match-background-color: hsl(var(--hsl-base0A) / 40%);
+  --editor-search-match-outline: none;
+  --editor-search-match-selected-background-color: hsl(var(--hsl-base09) / 40%);
+  --editor-search-match-selected-outline: 1px solid var(--bd-base02);
+  --editor-placeholder-color: var(--bd-base06);
+  --editor-highlight-space-color: var(--bd-bg-highlight);
+  --editor-highlight-tab-background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20"><path stroke="%23888" stroke-width="1" fill="none" d="M1 10H196L190 5M190 15L196 10M197 4L197 16"/></svg>');
+  --editor-highlight-tab-filter: 'none';
+  --editor-highlight-tab-opacity: 0.3;
+  --editor-trailing-space-background-color: var(--bd-base08);
+  --editor-fold-placeholder-border-radius: 0.2em;
+  --editor-fold-placeholder-color: var(--bd-base00);
+  --editor-fold-placeholder-border: 1px solid var(--bd-base03);
+  --editor-fold-placeholder-background-color: var(--bd-base05);
+  --editor-image-widget-backdrop-background-color: hsl(var(--hsl-base03) / 10%);
+  --editor-image-widget-backdrop-border: 1px solid var(--bd-base04);
 
-    .CodeMirror-scroll {
-      /* Color of otherwise un-styled text */
-      color: var(--base02);
-    }
-    .CodeMirror-gutters {
-      /* Gutter to the left */
-      background-color: transparent;
-      border-right: 1px solid hsl(0deg 100% 0% / 10%);
-    }
-    .CodeMirror-linenumber {
-      /* Line numbers in the gutter */
-      color: var(--base03);
-      opacity: 0.6;
-    }
-    .CodeMirror-selected {
-      /* Highlighed text */
-      background-color: var(--base05);
-    }
-    .CodeMirror-focused .CodeMirror-selected {
-      /* Highlighed text */
-      background-color: var(--base04);
-    }
-    .CodeMirror-cursor {
-      /* The cursor */
-      border-left: 1px solid var(--base00);
-    }
-    .CodeMirror-matchingbracket,
-    .CodeMirror-matchingtag {
-      /* When you click a tag/bracket and the matching one is highlighted */
-      background: var(--base03) !important;
-      border-bottom: 1px solid var(--base08) !important;
-    }
-    .CodeMirror-foldgutter-open:after {
-      /* Those little arrows in the gutter */
-      color: var(--base03);
-    }
-    .CodeMirror-foldgutter-folded:after {
-      /* The arrows after you collapse code */
-      color: var(--base03);
-    }
-    .CodeMirror.over-gutter,
-    .CodeMirror-activeline {
-      .CodeMirror-foldgutter-open:after {
-        /* Arrows when hovering on the gutter */
-        color: var(--base03);
-      }
-    }
-    .CodeMirror-foldmarker {
-      /* The [...] marking collapsed code */
-      border-color: var(--base03);
-      background-color: var(--base03);
-      color: var(--base02);
-    }
-    .CodeMirror .CodeMirror-linewidget img.inline-widget {
-      background: rgba(0, 0, 0, 0.05);
-    }
-    .CodeMirror-searching {
-      /* Ctrl + F results */
-      background-color: var(--base0D);
-      /* Selected result */
-      &.searching-current-match {
-        background-color: var(--base0C);
-      }
-    }
+  --md-codeblock-border-color: var(--bd-base04);
+  --md-codeblock-border-width: 1px;
+  --md-codeblock-background-color: hsl(var(--hsl-base07) / 5%);
+
+  --md-table-border-color: var(--bd-base04);
+  --md-table-border-width: 1px;
+  --md-table-background-color: hsl(var(--hsl-base05));
+
+  --md-blockquote-border-color: var(--bd-base06);
+}
+
+/*============================================================================
+  Syntax colours (classes produced by tokenHighlighter.ts)
+  ===========================================================================*/
+.cm-editor,
+.mde-preview .codeblock {
+  /* keywords -----------------------------------------------------------*/
+  .tok-keyword,
+  .tok-operator-keyword,
+  .tok-module-keyword {
+    color: var(--bd-base0F);
   }
 
-  /* All 'dem swatches */
-
-  .CodeMirror {
-    .cm-quote {
-      color: var(--base0F);
-      font-style: italic;
-    }
-    .cm-atom,
-    .cm-formatting-list.cm-variable-3 {
-      color: var(--base0C);
-    }
-
-    .cm-keyword,
-    .cm-formatting-list.cm-variable-2 {
-      color: var(--base0A);
-    }
-
-    .cm-url,
-    .cm-string,
-    .cm-string-2,
-    .cm-hr {
-      color: var(--base09);
-    }
-    .cm-number,
-    .cm-attribute,
-    .cm-plus {
-      color: var(--base0A);
-    }
-    .cm-def,
-    .cm-property {
-      color: var(--base0C);
-    }
-    .cm-variable {
-      color: var(--base0A);
-    }
-    .cm-operator,
-    .cm-meta,
-    .cm-bracket {
-      color: var(--base0E);
-    }
-    .cm-comment {
-      color: var(--base03);
-      font-style: italic;
-    }
-    .cm-error,
-    .cm-minus {
-      color: var(--base0B);
-    }
-    .cm-formatting-header {
-      opacity: 0.3;
-    }
-    .cm-header {
-      color: var(--base0A);
-    }
-    .cm-link {
-      color: var(--base0E);
-      text-underline-position: under;
-    }
-    .cm-rangeinfo {
-      color: var(--base0C);
-    }
-    .cm-qualifier,
-    .cm-builtin,
-    .cm-tag {
-      color: var(--base08);
-    }
-    .cm-whitespace::before {
-      color: var(--base04);
-      opacity: 0.4;
-    }
-    .cm-formatting-quote,
-    .cm-formatting-strong,
-    .cm-formatting-em {
-      opacity: 0.6;
-    }
-    .cm-strong {
-      color: var(--base0B);
-    }
-    .cm-em {
-      color: var(--base0C);
-    }
-
-    /* carriage return */
-    .CodeMirror-code > div > pre > span::after,
-    .CodeMirror-line > span::after {
-      color: var(--base00);
-      opacity: 0.4;
-    }
-
-    .cm-inline-code {
-      background: rgba(0, 0, 0, 0.02);
-      color: var(--base03);
-    }
-
-    .gfm-codeblock-bg.CodeMirror-linebackground {
-      background: rgba(0, 0, 0, 0.01);
-    }
-
-    .cm-table-sep,
-    .table-row.table-row-1 {
-      color: var(--base0E);
-    }
-
-    .cm-quote.cm-link-barelink {
-      font-style: normal;
-      color: var(--base0B);
-    }
+  /* basic names, deletes, chars, prop- & macro-names -------------------*/
+  .tok-name,
+  .tok-deleted,
+  .tok-character,
+  .tok-property-name,
+  .tok-macro-name {
+    color: var(--bd-base0C);
   }
 
-  /* Active Line Highlight support */
-  .CodeMirror-activeline-background,
-  .CodeMirror-activeline-gutter {
-    background-color: color-mix(
-      in srgb,
-      var(--base06),
-      transparent 70%
-    ) !important;
+  /* variable names -----------------------------------------------------*/
+  .tok-variable-name {
+    color: var(--bd-base0F);
+  }
+
+  /* function identifiers & calls --------------------------------------*/
+  .tok-variable-name.tok-function {
+    color: var(--bd-base0D);
+  }
+
+  /* labels -------------------------------------------------------------*/
+  .tok-label-name {
+    color: var(--bd-base09);
+  }
+
+  /* colour literals, constants, std-lib names --------------------------*/
+  .tok-color,
+  .tok-name.tok-constant,
+  .tok-name.tok-standard {
+    color: var(--bd-base09);
+  }
+
+  /* definitions & separators ------------------------------------------*/
+  .tok-name.tok-definition,
+  .tok-definition-keyword,
+  .tok-control-keyword,
+  .tok-separator {
+    color: var(--bd-base0E);
+  }
+
+  /* braces, square/angle brackets -------------------------------------*/
+  .tok-brace,
+  .tok-square-bracket,
+  .tok-angle-bracket {
+    color: var(--bd-base06);
+  }
+
+  /* annotations (highlighted in warning orange) ------------------------*/
+  .tok-annotation {
+    color: var(--bd-base09);
+  }
+
+  /* numbers, changed, modifier, self, namespace ------------------------*/
+  .tok-number,
+  .tok-changed,
+  .tok-modifier,
+  .tok-self,
+  .tok-namespace {
+    color: var(--bd-base09);
+  }
+
+  /* type & class names -------------------------------------------------*/
+  .tok-type-name,
+  .tok-class-name {
+    color: var(--bd-base0F);
+  }
+
+  /* operators ----------------------------------------------------------*/
+  .tok-operator,
+  .tok-deref-operator,
+  .tok-arithmetic-operator,
+  .tok-logic-operator,
+  .tok-bitwise-operator,
+  .tok-compare-operator,
+  .tok-update-operator,
+  .tok-definition-operator,
+  .tok-control-operator {
+    color: var(--bd-base06);
+  }
+
+  /* HTML/XML tag names -------------------------------------------------*/
+  .tok-tag-name {
+    color: var(--bd-base0C);
+  }
+
+  /* attribute names ----------------------------------------------------*/
+  .tok-attribute-name {
+    color: var(--bd-base0F);
+  }
+
+  /* regular expressions -----------------------------------------------*/
+  .tok-regexp {
+    color: var(--bd-base0B);
+  }
+
+  /* quotes / block-quotes ---------------------------------------------*/
+  .tok-quote:not(.md-alert) {
+    color: var(--bd-base0E);
+  }
+
+  /* strings ------------------------------------------------------------*/
+  .tok-string {
+    color: var(--bd-base0B);
+  }
+
+  /* links --------------------------------------------------------------*/
+  .tok-link {
+    color: var(--bd-base0D);
+    text-decoration: underline;
+    text-underline-position: under;
+  }
+
+  /* urls, escapes, special strings ------------------------------------*/
+  .tok-url,
+  .tok-link.tok-url,
+  .tok-escape,
+  .tok-string.tok-special {
+    color: var(--bd-base0D);
+  }
+
+  /* meta / pre-processor ----------------------------------------------*/
+  .tok-meta {
+    color: var(--bd-base08);
+  }
+
+  /* comments -----------------------------------------------------------*/
+  .tok-comment,
+  .tok-line-comment,
+  .tok-block-comment,
+  .tok-doc-comment {
+    color: var(--bd-base06);
+    font-style: italic;
+  }
+
+  /* monospace (inline code) -------------------------------------------*/
+  .tok-monospace {
+    color: var(--bd-base01);
+    background: hsl(var(--hsl-base07) / 5%);
+  }
+
+  /* emphasis variants --------------------------------------------------*/
+  .tok-strong {
+    color: var(--bd-base08);
+    font-weight: bold;
+  }
+  .tok-emphasis {
+    color: var(--bd-base0E);
+    font-style: italic;
+  }
+  .tok-strikethrough {
+    text-decoration: line-through;
+  }
+
+  /* headings -----------------------------------------------------------*/
+  .tok-heading,
+  .tok-heading-1,
+  .tok-heading-2,
+  .tok-heading-3,
+  .tok-heading-4,
+  .tok-heading-5,
+  .tok-heading-6 {
+    color: var(--bd-base07);
+    font-weight: bold;
+  }
+
+  /* atoms, booleans, special vars -------------------------------------*/
+  .tok-atom,
+  .tok-bool,
+  .tok-variable-name.tok-special {
+    color: var(--bd-base09);
+  }
+
+  /* processing instructions & inserted text ---------------------------*/
+  .tok-processing-instruction,
+  .tok-inserted {
+    color: var(--bd-base0B);
+  }
+
+  /* content separator --------------------------------------------------*/
+  .tok-content-separator {
+    color: var(--bd-base0D);
+  }
+
+  /* invalid / unsyntactic tokens --------------------------------------*/
+  .tok-invalid {
+    color: var(--bd-base08);
+    border-bottom: 1px dotted var(--bd-base08);
+  }
+
+  .md-header-mark {
+    opacity: 0.3;
+  }
+  .md-hard-break {
+    /* add styles if desired */
+  }
+  .md-quote-mark.tok-quote {
+    color: var(--bd-base0E);
+  }
+  .md-list-mark {
+    /* … */
+  }
+  .md-link-mark {
+    /* … */
+  }
+  .md-emphasis-mark {
+    /* … */
+  }
+  .md-code-mark {
+    /* … */
+  }
+  .md-table-delimiter {
+    /* … */
+  }
+  .md-strikethrough-mark {
+    /* … */
+  }
+  .md-task-marker {
   }
 }


### PR DESCRIPTION
This pull request updates the Default Light Syntax Theme for Inkdrop to be compatible with Inkdrop 6 and provides extensive documentation for theme developers. The main changes include updating the package for the new Inkdrop version, removing legacy build scripts, and introducing a comprehensive README that explains the theme structure and migration steps.

**Documentation improvements:**

* Added a detailed `README.md` describing how syntax themes work in Inkdrop 6, the structure of `styles/index.css`, and guidance for migrating themes from Inkdrop 5.

**Package and compatibility updates:**

* Updated `package.json` to version 2.0.0 and changed the Inkdrop engine requirement from `^5.x` to `^6.x` to ensure compatibility with Inkdrop 6.
* Removed the legacy `lessc` build script from `package.json`, reflecting the switch to a pure CSS theme compatible with modern Inkdrop.